### PR TITLE
Handle ampersand in URI (using decodeURIComponent)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -315,13 +315,13 @@ var Connection = (function () {
             if (res.statusCode >= 400)
                 return callback(new HTTPError(res));
             try {
-                var decodedPath_1 = decodeURI(path);
+                var decodedPath_1 = decodeURIComponent(path);
                 var results = xml_js_builder_1.XML.parse(body)
                     .find('DAV:multistatus')
                     .findMany('DAV:response')
                     .map(function (el) {
                     var fullPathStart = _this.root.length - 1;
-                    var href = el.find('DAV:href').findText(), pathname = Url.parse(href).pathname, fullPath = decodeURI(pathname.slice(fullPathStart)), hrefWithoutTrailingSlash = (href.lastIndexOf('/') === href.length - 1 ? href.slice(0, -1) : href), name = Path.basename(fullPath);
+                    var href = el.find('DAV:href').findText(), pathname = Url.parse(href).pathname, fullPath = decodeURIComponent(pathname.slice(fullPathStart)), hrefWithoutTrailingSlash = (href.lastIndexOf('/') === href.length - 1 ? href.slice(0, -1) : href), name = Path.basename(fullPath);
                     return { el: el, hrefWithoutTrailingSlash: hrefWithoutTrailingSlash, fullPath: fullPath, name: name };
                 })
                     .filter(function (_a) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -463,7 +463,7 @@ export class Connection
             
             try
             {
-                  const decodedPath = decodeURI(path);
+                  const decodedPath = decodeURIComponent(path);
 
                   const results = XML.parse(body)
                     .find('DAV:multistatus')
@@ -473,7 +473,7 @@ export class Connection
 
                         const href = el.find('DAV:href').findText(),
                             pathname = Url.parse(href).pathname,
-                            fullPath = decodeURI(pathname.slice(fullPathStart)),
+                            fullPath = decodeURIComponent(pathname.slice(fullPathStart)),
                             hrefWithoutTrailingSlash = (href.lastIndexOf('/') === href.length - 1 ? href.slice(0, -1) : href),
                             name = Path.basename(fullPath);
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@ const subTree = {
         'file2.2': webdav.ResourceType.File,
         'file2.3': webdav.ResourceType.File
     },
-    'folder test é': {
+    'folder test é &': {
         'file1': webdav.ResourceType.File
     },
     'file1': webdav.ResourceType.File,
@@ -378,8 +378,8 @@ function testReadDirQueriedPathEntryBug() {
         })
     })
 
-    start('"readdir" on "/test folder é"', (end, expected) => {
-        connection.readdir('/folder test é', (e, files) => {
+    start('"readdir" on "/test folder é &"', (end, expected) => {
+        connection.readdir('/folder test é &', (e, files) => {
             expected(e) && expected(files, [ 'file1' ]);
             end();
         })
@@ -387,8 +387,8 @@ function testReadDirQueriedPathEntryBug() {
 
     // Some WebDAV implementation will return 404s if the
     // URL is not escaped, so this needs to work too.
-    start('"readdir" on escaped-"/test folder é"', (end, expected) => {
-        connection.readdir(encodeURI('/folder test é'), (e, files) => {
+    start('"readdir" on escaped-"/test folder é &"', (end, expected) => {
+        connection.readdir('/folder%20test%20%C3%A9%20%26', (e, files) => {
             expected(e) && expected(files, [ 'file1' ]);
             end();
         })


### PR DESCRIPTION
We had some issue with ampersands in filenames when querying folder contents from Nextcloud. When we used readdir to get the files with ampersands, they were not decoded correctly ("Smith %26 Son" instead of "Smith & Son"). This changes should fix the issue.
Added test with filename including ampersand (%26).