### PR TITLE
Adding a sanity test in 'exists(path)' function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export class Connection
         })
     }
 
-    exists(path : string, callback : (error : Error, exists : boolean) => void) : void
+    exists(path : string, callback : (error : Error, exists ?: boolean) => void) : void
     {
         this.request({
             url: path,
@@ -284,7 +284,10 @@ export class Connection
                 depth: '0'
             }
         }, (e, res, body) => {
-            callback(e, res.statusCode <= 400);
+            if(e)
+                return callback(e);
+
+            callback(null, res.statusCode <= 400);
         })
     }
 


### PR DESCRIPTION
**Reason**

There is at least one error type (`ECONNRESET`) in [request](https://www.npmjs.com/package/request) that causes responses to be null. This will cause an uncaught error in the following line whenever this error occurs: 

https://github.com/OpenMarshal/npm-WebDAV-Client/blob/ba7280b5eca3b5c31f80525c8b9b4f30073bd520/src/index.ts#L287

**Fix**

Tests if any error is returned by the request before accessing the `statusCode` of the response.

**Warning**

This PR changes the signature of the callback in this function from: `(error : Error, exists : boolean)` to `(error : Error, exists ?: boolean)`. Which means that if an error occurs, the boolean will not be returned!!!

closes #14 